### PR TITLE
Add new layout organizing Upcoming/Past by series

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -51,6 +51,8 @@ class AppController extends Controller {
 
         if(array_key_exists('ext', $this->request->params) && $this->request->params['ext'] == 'embed') {
             $this->layout = 'embed';
+        } else if (Configure::read('Club.layout') === 'series') {
+            $this->layout = 'default';
         } else {
             // Set layout based on club's layout parameter
             $this->layout = Configure::read('Club.layout');

--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -296,19 +296,19 @@ class EventsController extends AppController {
         $this->set('eventId', $id);
     }
 
-    function upcoming($limit = 0)
+    function upcoming($limit = 0, $series_id = NULL)
     {
-        return $this->Event->findUpcoming($limit);
+        return $this->Event->findUpcoming($limit, $series_id);
     }
 
-    function past($limit = 0)
+    function past($limit = 0, $series_id = NULL)
     {
-        return $this->Event->findPast($limit);
+        return $this->Event->findPast($limit, $series_id);
     }
 
-    function ongoing($limit = 0)
+    function ongoing($limit = 0, $series_id = NULL)
     {
-        return $this->Event->findOngoing($limit);
+        return $this->Event->findOngoing($limit, $series_id);
     }
 
     function _isBeforeNow($dateTime) {

--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -69,19 +69,19 @@ class Event extends AppModel {
         return true;
     }
 
-    function findOngoing($limit) {
-        return $this->findEventsNearNow('ongoing', $limit);
+    function findOngoing($limit, $series_id) {
+        return $this->findEventsNearNow('ongoing', $limit, $series_id);
     }
 
-    function findUpcoming($limit) {
-        return $this->findEventsNearNow('after', $limit);
+    function findUpcoming($limit, $series_id) {
+        return $this->findEventsNearNow('after', $limit, $series_id);
     }
 
-    function findPast($limit) {
-        return $this->findEventsNearNow('before', $limit);
+    function findPast($limit, $series_id) {
+        return $this->findEventsNearNow('before', $limit, $series_id);
     }
 
-    private function findEventsNearNow($beforeOrAfterNow, $limit) {
+    private function findEventsNearNow($beforeOrAfterNow, $limit, $series_id) {
         $time = new DateTime();
         $time = $time->format('Y-m-d H:i:s');
         if ($beforeOrAfterNow === 'before') {
@@ -112,6 +112,19 @@ class Event extends AppModel {
         } else {
             die("Event.findEventsNearNow: invalid parameter: $beforeOrAfterNow");
         }
+
+        if ($series_id != NULL) {
+            if ($series_id > 0) {
+                $conditions['AND'][] = array(
+                    'Event.series_id =' => $series_id,
+                );
+            } else {
+                // Non-series events
+                $conditions['AND'][] = array(
+                    'Event.series_id =' => NULL,
+                );
+            }
+	}
 
         $options = array(
             'limit' => $limit,

--- a/app/View/Clubs/edit.ctp
+++ b/app/View/Clubs/edit.ctp
@@ -42,7 +42,7 @@
 <div class="form-group">
     <label class="col-sm-2 control-label">Page Layout</label>
     <div class="col-sm-10">
-        <?php echo $this->Form->input('layout', array('type' => 'select', 'options' => array('default' => 'Active Club Layout', 'other' => 'Inactive Club Layout'), 'div' => false, 'label' => false, 'class' => 'form-control')) ?>
+        <?php echo $this->Form->input('layout', array('type' => 'select', 'options' => array('default' => 'Active Club Layout', 'series' => 'Active Club Layout - Past/Upcoming Events By Series', 'other' => 'Inactive Club Layout'), 'div' => false, 'label' => false, 'class' => 'form-control')) ?>
     </div>
 </div>
 <div class="form-group">

--- a/app/View/Elements/Events/box-list.ctp
+++ b/app/View/Elements/Events/box-list.ctp
@@ -1,6 +1,11 @@
 <?php 
 // Filter can either be 'upcoming' or 'past'
-$events = $this->requestAction('events/'.$filter.'/'.$limit);
+if (isset($series_id)) {
+    $events = $this->requestAction('events/'.$filter.'/'.$limit.'/'.$series_id);
+} else {
+    $events = $this->requestAction('events/'.$filter.'/'.$limit);
+}
+
 foreach($events as $event) {
     $startDate = new DateTime($event["Event"]["date"]);    
     $finishDate = new DateTime($event["Event"]["finish_date"]);    

--- a/app/View/Elements/Events/summary_list.ctp
+++ b/app/View/Elements/Events/summary_list.ctp
@@ -1,0 +1,12 @@
+<?php
+$events = array();
+$events["Ongoing"] = $this->element('Events/box-list', array('filter' => 'ongoing', 'limit' => '-1'));
+$events["Upcoming"] = $this->element('Events/box-list', array('filter' => 'upcoming', 'limit' => '4'));
+$events["Past"] = $this->element('Events/box-list', array('filter' => 'past', 'limit' => '2'));
+
+foreach($events as $title => $content) {
+    if(!empty($content)) {
+        echo "<h3>${title}</h3>";
+        echo $content;
+    }
+}

--- a/app/View/Elements/Events/summary_list_by_series.ctp
+++ b/app/View/Elements/Events/summary_list_by_series.ctp
@@ -1,0 +1,47 @@
+<?php
+$ongoing = $this->element('Events/box-list', array('filter' => 'ongoing', 'limit' => '-1'));
+
+if(!empty($ongoing)) {
+    echo "<h3>${title}</h3>";
+    echo $ongoing;
+}
+
+$seriesSet = $this->requestAction('series/index');
+
+$upcoming = array();
+foreach($seriesSet as $series) {
+    if (!$series["Series"]["is_current"]) {
+        continue;
+    }
+
+    $upcoming[$series["Series"]["name"]] = $this->element('Events/box-list',
+                array('filter' => 'upcoming', 'limit' => '2', 'series_id' => $series["Series"]["id"]));
+}
+$upcoming["Other"] = $this->element('Events/box-list', array('filter' => 'upcoming', 'limit' => '2', 'series_id' => 0));
+
+echo "<h3>Upcoming</h3>";
+foreach($upcoming as $title => $content) {
+    if(!empty($content)) {
+        echo "<h4>${title}</h4>";
+        echo $content;
+    }
+}
+
+$past = array();
+foreach($seriesSet as $series) {
+    if (!$series["Series"]["is_current"]) {
+        continue;
+    }
+
+    $past[$series["Series"]["name"]] = $this->element('Events/box-list',
+                array('filter' => 'past', 'limit' => '1', 'series_id' => $series["Series"]["id"]));
+}
+$past["Other"] = $this->element('Events/box-list', array('filter' => 'past', 'limit' => '1', 'series_id' => 0));
+
+echo "<h3>Past</h3>";
+foreach($past as $title => $content) {
+    if(!empty($content)) {
+        echo "<h4>${title}</h4>";
+        echo $content;
+    }
+}

--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -6,16 +6,10 @@
           <h2>Events</h2>
         </header>
         <?php
-        $events = array();
-        $events["Ongoing"] = $this->element('Events/box-list', array('filter' => 'ongoing', 'limit' => '-1'));
-        $events["Upcoming"] = $this->element('Events/box-list', array('filter' => 'upcoming', 'limit' => '4'));
-        $events["Past"] = $this->element('Events/box-list', array('filter' => 'past', 'limit' => '2'));
-
-        foreach($events as $title => $content) {
-            if(!empty($content)) {
-                echo "<h3>${title}</h3>";
-                echo $content;
-            }
+        if (Configure::read('Club.layout') === 'series' ) {
+            echo $this->element('Events/summary_list_by_series');
+        } else {
+            echo $this->element('Events/summary_list');
         }
         ?>
 

--- a/app/webroot/css/whyjustrun.css
+++ b/app/webroot/css/whyjustrun.css
@@ -307,6 +307,10 @@ footer.main-footer div {
     text-align: center;
 }
 
+.three-column .events-by-series h4 {
+    font-weight: bold;
+}
+
 .news-item {
     margin-bottom: 10px;
     margin-top: 10px;


### PR DESCRIPTION
First a bit of background on why this would be useful: Sage originated in Kamloops, but has since expanded/moved to the surrounding communities of Salmon Arm, Revelstoke, and a little bit to Kelowna.  To differentiate what city the event is in, each city has their own series.  However, we occasionally have three events in quick succession of each other and sometimes one region's don't show up for very long if at all in the Past Events and sometimes even Upcoming Events.

This layout file changes the Past/Upcoming Events section to be grouped by series.  It can be visually previewed at https://tst.jonbakker.ca/

Note that I've left one TODO in the code where it might be beneficial to do a DB schema upgrade over the null checking code.