### PR TITLE
Show event series colour in Events List as well

### DIFF
--- a/app/webroot/js/wjr/event-list.js
+++ b/app/webroot/js/wjr/event-list.js
@@ -215,9 +215,9 @@ define(['jquery', 'moment', 'knockout', './club'], function ($, moment, ko, club
     
         if (coloringStyle === "club-only") {
           if (clubId == club.id) {
-            color = '#238216';
+            color = series.children('Color').text() ? series.children('Color').text() : '#000000';
           } else {
-            color = '#000000';
+            color = '#6d6d6d';
           }
         } else {
           color = series.children('Color').text();


### PR DESCRIPTION
I changed the Calendar view to show events by Series colour, but missed the List view.

Non-series events show up black (like on the Calendar), events from other clubs show up gray as can be seen at https://tst.jonbakker.ca/events/listing (GVOC events used to better demonstrate the colour differences, notably OBC AGM is not part of a series)