### PR TITLE
Add registration deadline implementation

### DIFF
--- a/app/Controller/EventsController.php
+++ b/app/Controller/EventsController.php
@@ -88,6 +88,12 @@ class EventsController extends AppController {
                 unset($this->request->data['Event']['finish_time']);
             }
 
+            if(!empty($this->request->data['Event']['deadline_date'])) {
+                $this->request->data['Event']['registration_deadline'] = TimeLib::mysqlDateTimeFormat($this->request->data['Event']['deadline_date'], $this->request->data['Event']['deadline_time']);
+                unset($this->request->data['Event']['deadline_date']);
+                unset($this->request->data['Event']['deadline_time']);
+            }
+
             // Don't save the default location
             if(floatval($this->request->data['Event']['lat']) == Configure::read('Club.lat') && floatval($this->request->data['Event']['lng']) == Configure::read('Club.lng')) {
                 $this->request->data['Event']['lat'] = null;
@@ -209,6 +215,12 @@ class EventsController extends AppController {
 
         $startTime = new DateTime($event["Event"]["utc_date"]);
         $event["Event"]["completed"] = ($this->_isBeforeNow($startTime));
+        if (!empty($event["Event"]["utc_registration_deadline"])) {
+            $registrationDeadline = new DateTime($event["Event"]["utc_registration_deadline"]);
+            $event["Event"]["registration_open"] = !($this->_isBeforeNow($registrationDeadline));
+        } else {
+            $event["Event"]["registration_open"] = !$event["Event"]["completed"];
+        }
 
         foreach($event["Course"] as &$course) {
             $course["Result"] = @Set::sort($course["Result"], "{n}.User.name", 'asc');

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -114,6 +114,9 @@ class AppModel extends Model {
             } else if($key === 'finish_date' && !empty($value)){
                 $results['utc_finish_date'] = $value;
                 $value = $this->convertDate($value, $from, $to);
+            } else if ($key === 'registration_deadline' && !empty($value)){
+                $results['utc_registration_deadline'] = $value;
+                $value = $this->convertDate($value, $from, $to);
             }
         }
     }

--- a/app/View/Elements/Events/course_registration.ctp
+++ b/app/View/Elements/Events/course_registration.ctp
@@ -3,9 +3,6 @@
 // count($courses) should be > 0
 assert(count($courses) > 0);
 ?>
-<header>
-    <h2>Course Registration</h2>
-</header>
 <div class="courses">
     <?php 
     $userId = $this->User->id();
@@ -14,7 +11,7 @@ assert(count($courses) > 0);
     <div class="course">
         <div class="course-info">
             <div class="pull-right">
-                <?php if($course["registered"] === false) { ?>
+                <?php if($course["registered"] === false && $reg_open) { ?>
                 <div class="btn-group">
                     <a class="btn btn-success" href="/courses/register/<?php echo $course['id'] ?>/<?php echo $userId ?>"><span class="glyphicon glyphicon-plus"></span> Register</a>
                 </div>
@@ -43,4 +40,8 @@ assert(count($courses) > 0);
     <?php } ?>
 </div>
 
-<?php echo $this->element('Events/register_others', array('courses' => $courses, 'userId' => $userId)) ?>
+<?php
+if ($reg_open) {
+    echo $this->element('Events/register_others', array('courses' => $courses, 'userId' => $userId));
+}
+?>

--- a/app/View/Elements/Events/registration_section.ctp
+++ b/app/View/Elements/Events/registration_section.ctp
@@ -20,5 +20,23 @@ if($event["Event"]["completed"] === true) {
     </div>
 <?php
 } else if(count($event["Course"]) > 0) {
-    echo $this->element('Events/course_registration', array('courses' => $event['Course']));
+?>
+<header>
+    <h2>Course Registration</h2>
+<?php
+if (!empty($event['Event']['registration_deadline'])) {
+    if ($event['Event']['registration_open']) {
+        $deadlineDate = new DateTime($event['Event']['registration_deadline']);
+        $deadlineDateFormatted = "Deadline " . $deadlineDate->format('M jS g:ia');
+    } else {
+        $deadlineDateFormatted = "Registration is Closed";
+    }
+?>
+    <h4 class="reg-deadline-header"><?php echo $deadlineDateFormatted ?></h4>
+<?php
+}
+?>
+</header>
+<?php
+    echo $this->element('Events/course_registration', array('courses' => $event['Course'], 'reg_open' => $event['Event']['registration_open']));
 } ?>

--- a/app/View/Events/edit.ctp
+++ b/app/View/Events/edit.ctp
@@ -19,6 +19,14 @@ if(!empty($this->data['Event']['finish_date'])) {
     $finishTime = $finishDate = "";
 }
 
+if(!empty($this->data['Event']['registration_deadline'])) {
+    $parts = explode(' ', $this->data['Event']['registration_deadline']);
+    $deadlineDate = $parts[0];
+    $deadlineTime = substr($parts[1], 0, -3);
+} else {
+    $deadlineTime = $deadlineDate = "";
+}
+
 echo $this->Form->create('Event', array('class' => 'form-horizontal', 'data-validate' => 'ketchup', 'url' => array('action' => 'edit')));
 // Hidden JSON encoded organizer data from the edit organizers UI
 echo $this->Form->input('id', array('type' => 'hidden'));
@@ -46,6 +54,20 @@ echo $this->Form->input('name', array('data-validate' => 'validate(required)', '
             </div>
             <div class="form-group inline-validated">
                 <?php echo $this->Form->text('finish_time', array('size' => '5', 'placeholder' => 'hh:mm', 'maxLength' => 5, 'value' => $finishTime, 'data-validate' => 'validate(time, requires(EventFinishDate, finish date))', 'data-format' => 'HH:mm', 'div' => false, 'class' => 'form-control time-picker', 'label' => false)) ?>
+            </div>
+            <span class="inline-validated-help"> (optional)</span>
+        </div>
+    </div>
+</div>
+<div class="form-group">
+    <label class="control-label col-sm-2">Registration Deadline</label>
+    <div class="col-sm-10">
+        <div class="form-inline">
+            <div class="form-group inline-validated">
+                <?php echo $this->Form->text('deadline_date', array('size' => '10', 'value' => $deadlineDate, 'maxLength' => 10, 'placeholder' => 'yyyy-mm-dd', 'data-validate' => 'validate(date, date_before(EventDate, EventTime, EventDeadlineDate, EventDeadlineTime))', 'class' => 'form-control date-picker', 'data-format' => 'YYYY-MM-DD', 'div' => false, 'label' => false)) ?>
+            </div>
+            <div class="form-group inline-validated">
+                <?php echo $this->Form->text('deadline_time', array('size' => '5', 'placeholder' => 'hh:mm', 'maxLength' => 5, 'value' => $deadlineTime, 'data-validate' => 'validate(time, requires(EventDeadlineDate, deadline date))', 'data-format' => 'HH:mm', 'div' => false, 'class' => 'form-control time-picker', 'label' => false)) ?>
             </div>
             <span class="inline-validated-help"> (optional)</span>
         </div>

--- a/app/webroot/css/whyjustrun.css
+++ b/app/webroot/css/whyjustrun.css
@@ -16,6 +16,12 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+/* Registration deadline additional classes */
+.reg-deadline-header {
+    color: #d2322d;
+    padding: 5px;
+}
+
 /* Use to ensure the image fits within the responsive column*/
 .fitting-image {
     max-width: 100%;


### PR DESCRIPTION
Requires changes to core (https://github.com/WhyJustRun/Core/pull/48) as well for the DB side of things.  Live preview at https://tst.jonbakker.ca/events/view/14 and https://tst.jonbakker.ca/events/view/15 for both before and after registration deadline views.

The registration deadline is completely optional, there should be no difference to the current behaviour if no deadline is added.

Note that it is currently possible to unregister or change/add a comment after the deadline.